### PR TITLE
ci: standardize security posture (gitleaks + dependency-review + scorecard, explicit permissions)

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,23 @@
+name: OpenSSF Scorecard
+
+# Supply-chain posture scoring (branch protection, pinned actions, token
+# permissions, …). Runs on default-branch push and on a weekly schedule;
+# results upload to the code-scanning dashboard.
+
+on:
+  push:
+    branches: [main, master]
+  schedule:
+    - cron: '0 0 * * 0'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  scorecard:
+    uses: netresearch/.github/.github/workflows/scorecard.yml@main
+    permissions:
+      contents: read
+      security-events: write
+      id-token: write
+      actions: read

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,14 +1,41 @@
 name: Security
 
+# Aggregated security scans: secret scanning (gitleaks), dependency review on
+# PRs, and a Node.js dependency audit.
+#
+# Top-level `permissions: {}` denies everything by default; each reusable
+# caller job re-declares the exact union its reusable requires, so the token
+# passed to each reusable is fully explicit and never relies on the repo
+# default (default_workflow_permissions). This is the same contract proven in
+# netresearch/.github's go-app / php-module templates.
+
 on:
-  pull_request:
-    branches: [main, master]
   push:
     branches: [main, master]
+  pull_request:
+
+permissions: {}
 
 jobs:
+  gitleaks:
+    uses: netresearch/.github/.github/workflows/gitleaks.yml@main
+    permissions:
+      contents: read
+      security-events: write
+    secrets:
+      GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
+
+  dependency-review:
+    if: github.event_name == 'pull_request'
+    uses: netresearch/.github/.github/workflows/dependency-review.yml@main
+    permissions:
+      contents: read
+      pull-requests: write
+
   node-audit:
     uses: netresearch/.github/.github/workflows/node-audit.yml@main
+    permissions:
+      contents: read
     with:
       package-manager: yarn
       audit-level: high


### PR DESCRIPTION
Standardizes the Security workflow to the netresearch posture used by the other repo classes:

- **gitleaks** — secret scanning
- **dependency-review** — runs on PRs
- **scorecard.yml** — OpenSSF supply-chain posture (new file)
- existing **node-audit** kept (yarn / high)

Every reusable caller job declares its exact permission union under a top-level `permissions: {}`, so the token passed to each reusable is explicit and never relies on `default_workflow_permissions` — making the planned org-wide default→read flip safe. Custom `codeql.yml` is unchanged.