### PR TITLE
chore(renovate): hold TypeScript below v7

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,5 +7,13 @@
   ],
   "automerge": true,
   "automergeType": "pr",
-  "platformAutomerge": true
+  "platformAutomerge": true,
+  "packageRules": [
+    {
+      "description": "Hold TypeScript below v7 until typescript-eslint publishes TS7 peer support (currently <6.1.0). TS7 also removes baseUrl and moduleResolution=node10, which tsconfig still relies on; migrate tsconfig before lifting this.",
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["typescript"],
+      "allowedVersions": "<7"
+    }
+  ]
 }


### PR DESCRIPTION
Renovate has been proposing `typescript@^7.0.0` (#454). TypeScript 7 is not installable in this repo today, so the PR cannot go green.

## Why

Two independent blockers, both verified:

1. **Toolchain has no TS7 release.** `typescript-eslint` declares peer `typescript@">=4.8.4 <6.1.0"`. No published version supports TS7, so npm fails with `ERESOLVE` and eslint crashes at module load (`Cannot read properties of undefined (reading 'Cjs')`).
2. **tsconfig needs migrating.** TS7 removed `baseUrl` (`error TS5102`) and `moduleResolution=node10` (`error TS5108`); `tsconfig.json` still sets both.

## What this does

Pins Renovate to `typescript@<7` so it stops opening a PR that cannot pass. The `description` field records the exact condition for lifting the rule.

## Follow-up

Lift the rule once `typescript-eslint` publishes a TS7 peer range, and land the tsconfig migration (`paths` mapping + `node16`/`bundler`) before the bump.

Note: the `node-audit` job is red on `main` independently of this — 7 high-severity `jsonata` advisories (GHSA-86vw-mfpg-wwv9), failing since at least 2026-07-03. That needs its own fix and is not addressed here.

Closes #454