### PR TITLE
fix(security): upgrade jsonata to 2.2.2 (GHSA-86vw-mfpg-wwv9)

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,12 @@
 	"dependencies": {
 		"@netresearch/node-magento-eqp": "^5.0.0"
 	},
+	"overrides": {
+		"jsonata": "^2.2.0"
+	},
+	"resolutions": {
+		"jsonata": "^2.2.0"
+	},
 	"devDependencies": {
 		"@eslint/js": "^10.0.1",
 		"@types/node": "^24.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1103,10 +1103,10 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==
 
-jsonata@2.0.5:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/jsonata/-/jsonata-2.0.5.tgz#2b3b5098c019b264c4fae061a9cb24d59c7115a2"
-  integrity sha512-wEse9+QLIIU5IaCgtJCPsFi/H4F3qcikWzF4bAELZiRz08ohfx3Q6CjDRf4ZPF5P/92RI3KIHtb7u3jqPaHXdQ==
+jsonata@2.0.5, jsonata@^2.2.0:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/jsonata/-/jsonata-2.2.2.tgz#69ec3138d3eaa8250e70c10ba86abaff38bf5f3e"
+  integrity sha512-XDFH2PuaAXv0AXJEWwElXbqADmKFGKMLMkFb+qOz0EhjQW2EIJ6pgtordLU+4u3IVERyBfqy6bi6kZKEncvRqA==
 
 keyv@^4.5.4:
   version "4.5.4"


### PR DESCRIPTION
## Problem
The **Security** workflow (`npm audit --audit-level=high`) fails on `main`:

```
jsonata  <2.2.0  — high — resource exhaustion (GHSA-86vw-mfpg-wwv9)
7 high severity vulnerabilities
```

jsonata is pulled in **only transitively and dev-only**, via `@types/node-red` → `@types/node-red__util`, which hard-pins `jsonata: 2.0.5`. Nothing vulnerable ships to consumers (the production tree — only `@netresearch/node-magento-eqp` — is clean). `@types/node-red@^1.3.5` is already the latest tag, so the vulnerable pin cannot be removed by upgrading the direct dependency.

## Fix
Upgrade jsonata itself to the patched **2.2.2**:
- `overrides` — read by npm when the audit synthesizes its lockfile (`npm i --package-lock-only`), so the gate sees jsonata ≥2.2.0.
- `resolutions` — pins it for Yarn Classic; `yarn.lock` change is limited to the single jsonata entry.

## Verification
- `yarn install --frozen-lockfile` → passes (lockfile consistent).
- `npm audit --audit-level=high` → **0 vulnerabilities** (exit 0).