### PR TITLE
chore(ci): route CodeQL through shared netresearch/.github reusable

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,28 +11,14 @@ on:
 permissions: {}
 
 jobs:
+  # CodeQL runs through the org's shared reusable in netresearch/.github,
+  # so the pinned github/codeql-action versions are maintained centrally
+  # instead of bumped per-repo by Renovate.
   analyze:
-    name: Analyze
-    runs-on: ubuntu-latest
-    timeout-minutes: 360
+    uses: netresearch/.github/.github/workflows/codeql.yml@main
     permissions:
       actions: read
       contents: read
       security-events: write
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
-        with:
-          languages: javascript
-
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
-
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
-        with:
-          category: '/language:javascript'
+    with:
+      languages: javascript-typescript


### PR DESCRIPTION
Replaces inline `github/codeql-action` with the org's `codeql.yml` reusable (`languages: javascript-typescript`). Centralizes the codeql-action pin. CodeQL is not a required check here, so no branch-protection change.