### PR TITLE
chore(ci): route PR quality gates and dependency auto-merge through shared reusables

### DIFF
--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -1,59 +1,32 @@
-# Auto-merge bot PRs: Dependabot, Renovate, and release-please.
-# Requires: branch protection with required status checks (--auto flag needs it).
+# Auto-merge dependency PRs (Dependabot, Renovate), routed through the org
+# shared reusable so this workflow has zero step-level action uses.
 #
-# SECURITY: This workflow uses pull_request_target which runs with base branch
-# permissions. NEVER add an actions/checkout step here -- that would allow code
-# from the PR to execute with write access to the repository.
+# Requires: branch protection with required status checks (`--auto` needs it).
+#
+# `merge-strategy: rebase` is pinned deliberately. The reusable's auto-detector
+# would pick `--merge` here (this repo has squash disabled, merge commits and
+# rebase enabled), while this repo has always rebase-merged bot PRs.
+#
+# SECURITY: pull_request_target is required so that approving and enabling
+# auto-merge on dependency PRs gets a write-scoped token, which pull_request
+# does not provide. The called reusable only runs gh-CLI review/merge steps
+# gated on dependabot/renovate authorship -- it never checks out or executes
+# PR head code, so the usual pull_request_target risk does not apply.
 
-name: Auto-merge bot PRs
+name: Auto-merge dependency PRs
 
-on:
+on: # zizmor: ignore[dangerous-triggers]
   pull_request_target:
-    types: [opened, synchronize, reopened]
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   auto-merge:
-    name: Auto-merge bot PRs
-    runs-on: ubuntu-24.04
-    # Use user.login instead of actor -- actor can change on synchronize/rerun.
-    # release-please PRs come from github-actions[bot]; scope with label check
-    # to avoid approving unrelated github-actions PRs.
-    if: >-
-      github.event.pull_request.user.login == 'dependabot[bot]' ||
-      github.event.pull_request.user.login == 'renovate[bot]' ||
-      (github.event.pull_request.user.login == 'github-actions[bot]' &&
-       contains(github.event.pull_request.labels.*.name, 'autorelease: pending'))
-
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
-        with:
-          egress-policy: audit
-
-      - name: Dependabot metadata
-        id: metadata
-        if: github.event.pull_request.user.login == 'dependabot[bot]'
-        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Auto-approve PR
-        # Skip for github-actions[bot] -- GITHUB_TOKEN can't approve
-        # its own PRs. release-please PRs need approval from pr-quality.yml
-        # using APPROVE_TOKEN, or manual approval.
-        if: github.event.pull_request.user.login != 'github-actions[bot]'
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh pr review --approve "$PR_URL"
-
-      - name: Enable auto-merge
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        # --auto waits for required status checks before merging
-        run: gh pr merge --auto --rebase "$PR_URL"
+    # Union of the called workflow's job permissions (auto-merge declares
+    # contents: write + pull-requests: write).
+    uses: netresearch/.github/.github/workflows/auto-merge-deps.yml@main
+    permissions:
+      contents: write
+      pull-requests: write
+    with:
+      merge-strategy: rebase

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -1,13 +1,17 @@
-# Solo-maintainer auto-approve: approves PRs from repo collaborators and
-# trusted bots so that required_approving_review_count >= 1 is satisfied
-# without manual review.
+# Solo-maintainer auto-approve, routed through the org shared reusable so this
+# workflow has zero step-level action uses.
 #
-# For bot PRs (github-actions[bot]), GITHUB_TOKEN can't self-approve.
-# Set an APPROVE_TOKEN secret (PAT with repo scope) to approve bot PRs.
-# Without APPROVE_TOKEN, bot PRs require manual approval.
+# `auto-approve-require-write: true` keeps the historical authorisation model:
+# the PR author's repository permission is looked up explicitly
+# (GET /repos/{repo}/collaborators/{author}/permission) and the PR is only
+# approved for `admin` or `write`. It is NOT the weaker `author_association`
+# check the reusable applies by default.
 #
-# SECURITY: This workflow uses pull_request_target which runs with base branch
-# permissions. NEVER add an actions/checkout step here.
+# SECURITY: this workflow uses pull_request_target, so it runs with base-branch
+# permissions. The reusable checks out the BASE ref only (pull_request_target
+# resolves github.ref/github.sha to the base branch) with
+# persist-credentials: false, and never builds or executes repository code --
+# PR-authored code is never run with these permissions.
 
 name: PR Quality Gates
 
@@ -15,45 +19,22 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened]
 
-permissions:
-  pull-requests: write
+permissions: {}
 
 jobs:
-  auto-approve:
-    name: Auto-approve (collaborators)
-    runs-on: ubuntu-24.04
+  pr-quality:
+    name: PR Quality Gates
+    uses: netresearch/.github/.github/workflows/pr-quality.yml@main
+    # Union of the called workflow's job permissions (quality-gate and
+    # auto-approve both declare contents: read + pull-requests: write).
+    permissions:
+      contents: read
+      pull-requests: write
+    with:
+      auto-approve-require-write: true
+      auto-approve-message: >-
+        **Automated approval for maintainer PR**
 
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
-        with:
-          egress-policy: audit
 
-      - name: Check author permission
-        id: check-permission
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
-          REPO: ${{ github.repository }}
-        run: |
-          # Bots are trusted if they match known bot accounts
-          if [[ "$PR_AUTHOR" == "dependabot[bot]" || "$PR_AUTHOR" == "renovate[bot]" || "$PR_AUTHOR" == "github-actions[bot]" ]]; then
-            echo "permission=bot" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          PERMISSION=$(gh api "repos/$REPO/collaborators/$PR_AUTHOR/permission" --jq '.permission' 2>/dev/null || echo "none")
-          echo "permission=$PERMISSION" >> "$GITHUB_OUTPUT"
-
-      - name: Auto-approve (collaborator)
-        if: steps.check-permission.outputs.permission == 'admin' || steps.check-permission.outputs.permission == 'write'
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh pr review --approve "$PR_URL"
-
-      - name: Auto-approve (bot via APPROVE_TOKEN)
-        if: steps.check-permission.outputs.permission == 'bot'
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.APPROVE_TOKEN || secrets.GITHUB_TOKEN }}
-        run: gh pr review --approve "$PR_URL" || true
+        Author holds `write` or `admin` permission on this repository and all
+        automated quality gates passed.

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -17,7 +17,12 @@ name: PR Quality Gates
 
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened]
+    # `ready_for_review` is required: both jobs in the reusable are gated on
+    # `github.event.pull_request.draft == false`, so a PR opened as a draft is
+    # skipped. Without this activity type, undrafting alone would not re-trigger
+    # the workflow and the PR would never be quality-gated or approved until an
+    # unrelated push produced a `synchronize` event.
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions: {}
 


### PR DESCRIPTION
## What

Two workflows now call org reusables from
[`netresearch/.github`](https://github.com/netresearch/.github) instead of
running inline steps, plus one behaviour fix found in review:

1. `pr-quality.yml` → [`pr-quality.yml@main`](https://github.com/netresearch/.github/blob/main/.github/workflows/pr-quality.yml)
2. `auto-merge-deps.yml` → [`auto-merge-deps.yml@main`](https://github.com/netresearch/.github/blob/main/.github/workflows/auto-merge-deps.yml)
3. `pr-quality.yml` gains the `ready_for_review` trigger so draft PRs are not
   permanently skipped

Both files have **zero step-level `uses:`** — the only `uses:` in each is the
job-level reusable call.

---

# 1. `pr-quality.yml`

## How the original blocker was proven resolved

The earlier refusal was that the shared reusable authorised auto-approval on
`author_association` (`OWNER`/`MEMBER`/`COLLABORATOR`), which is *not* a
permission — it is returned for read/triage collaborators too — whereas this
repo did an explicit repository-permission lookup and approved only `admin`
or `write`. The hub gained `auto-approve-require-write` for exactly this.

Traced end to end against
[`netresearch/.github@c5fd7ea`](https://github.com/netresearch/.github/commit/c5fd7ea),
the reusable read in full — it is self-contained, it calls no further
reusable, so there is no second half that could undo the property. That trace
still holds on today's `main`:
[`compare/c5fd7ea...main`](https://github.com/netresearch/.github/compare/c5fd7ea...main)
lists no change to `.github/workflows/pr-quality.yml`, so the line numbers
below are still accurate.

| Old inline behaviour | Reusable with `auto-approve-require-write: true` |
|---|---|
| n/a | job `if` line 157: `inputs.auto-approve-require-write \|\| contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), …author_association)` → `true` short-circuits, the association filter is bypassed entirely |
| `PERMISSION=$(gh api "repos/$REPO/collaborators/$PR_AUTHOR/permission" --jq '.permission' 2>/dev/null \|\| echo "none")` (old line 44) | line 182 — byte-identical API call and identical `\|\| echo "none"` fail-closed fallback; the step is gated `if: inputs.auto-approve-require-write` (line 174) |
| `if: …permission == 'admin' \|\| …permission == 'write'` (old line 48) | line 194-196: `inputs.auto-approve-require-write == false \|\| contains(fromJSON('["admin","write"]'), steps.check-permission.outputs.permission)` — same admit set |

Verified against the live repo that the fallback really fails closed:
`GET /repos/netresearch/node-red-contrib-magento-eqp/collaborators/<login>/permission`
returns `read` for a non-write user and `none` for non-collaborators, so a
non-write author is never approved.

## Before / after

| Behaviour | Before | After | Notes |
|---|---|---|---|
| Trigger | `pull_request_target` `[opened, synchronize, reopened]` | `pull_request_target` `[opened, synchronize, reopened, ready_for_review]` | see §3 — bug fix, not a migration delta |
| Workflow name | `PR Quality Gates` | identical | preserved |
| Concurrency | none | none | preserved |
| Approve PR by `admin`/`write` collaborator | yes, via permission lookup | yes, same lookup (proof above) | preserved |
| Approve PR by read/triage collaborator or outsider | no | no | preserved (fail-closed `none`) |
| Approve `dependabot[bot]` / `renovate[bot]` PRs | yes (GITHUB_TOKEN) | no longer here — still approved by `auto-merge-deps.yml`, which keeps its `pull_request_target` trigger and its `gh pr review --approve` with `GITHUB_TOKEN` (now inside the shared reusable, see §2) | net effect unchanged |
| Approve `github-actions[bot]` (release-please) PRs | **no-op today** — `secrets.APPROVE_TOKEN \|\| secrets.GITHUB_TOKEN`; `APPROVE_TOKEN` exists neither as a repo secret (`total_count: 0`) nor as an org secret visible to this repo (8 org secrets, none named `APPROVE_TOKEN`), so it self-approves with `GITHUB_TOKEN` → HTTP 422, swallowed by `\|\| true` | no approval | unchanged in effect; release-please PRs still need manual approval, exactly as the old file's own header comment stated |
| Fork PR from a write-holder | would be approved (no fork check) | skipped (reusable line 155 requires same-repo head) | narrowing, fails closed; 0 of the last 100 PRs on this repo are cross-repository |
| PR size check | none | added (`quality-gate` job, thresholds 500/1000) | new, non-blocking (`core.warning` only) |
| `permissions` | top-level `pull-requests: write` | top-level `{}`, job-level `contents: read` + `pull-requests: write` | exact union of the reusable's two job permission blocks (`quality-gate` lines 96-98, `auto-approve` lines 160-162); a smaller grant would `startup_failure` |
| `actions/checkout` under `pull_request_target` | forbidden by file comment | the reusable checks out in `quality-gate` | **base ref only** — `pull_request_target` resolves `github.ref`/`github.sha` to the base branch, `persist-credentials: false`, and no repository code is built or executed. PR-authored code is still never run with these permissions. |

### Deliberate deltas

- `APPROVE_TOKEN` support is removed (the reusable has no such input). It is a
  latent capability only — the secret does not exist at repo or org level, so
  nothing that works today stops working. If bot self-approval is ever wanted,
  the input belongs in the hub reusable, not back here.
- `auto-approve-message` is overridden because the reusable's default links to
  `.github/SECURITY_CONTROLS.md`, which does not exist in this repo.

---

# 2. `auto-merge-deps.yml`

The inline job is replaced by a call to the org reusable. The file keeps
`pull_request_target` (needed for a write-scoped token on dependency PRs) and
top-level `permissions: {}` with the job-level union `contents: write` +
`pull-requests: write`, which is exactly what the reusable's single job
declares.

## Before / after

| Behaviour | Before | After | Notes |
|---|---|---|---|
| Trigger | `pull_request_target` `[opened, synchronize, reopened]` | `pull_request_target` (no `types:`) | identical — those three are GitHub's default activity types |
| Approve + auto-merge `dependabot[bot]` / `renovate[bot]` PRs | yes | yes | preserved |
| Merge strategy | hardcoded `--rebase` | `merge-strategy: rebase` passed to the reusable | preserved deliberately — the reusable's auto-detector would have picked `--merge` here, because this repo has `allow_squash_merge: false`, `allow_merge_commit: true`, `allow_rebase_merge: true` |
| Harden Runner | inline step | inside the reusable | preserved |
| `runs-on` | `ubuntu-24.04` | `ubuntu-latest` (reusable) | not a functional requirement |
| `permissions` | top-level `contents: write` + `pull-requests: write` | top-level `{}`, job-level same two scopes | union of the reusable's job permissions; a smaller grant would `startup_failure` |
| release-please arm (`github-actions[bot]` + `autorelease: pending`) | present | **removed** | see below |
| "Dependabot metadata" step | present | not called (the reusable runs it only under `safe-updates-only`) | its `id: metadata` outputs were never referenced by any step in the old file — it produced nothing |

### Why the release-please arm is removed, not ported

release-please is dead code in this repo:

- `gh pr list --state all --limit 100` returns **zero** PRs from a
  release-please head branch; the only "release" matches are Renovate PRs
  bumping the release-please action itself.
- Releases are actually cut manually by tag via `release.when-tagged.yml`.
- The arm was a no-op by construction anyway: the old file's own comment
  states GITHUB_TOKEN cannot approve its own PRs, and the approve step
  explicitly skipped `github-actions[bot]`.

So nothing that runs today stops running.
[netresearch/.github#261](https://github.com/netresearch/.github/issues/261),
which proposed adding this arm to the shared reusable, was closed for the
same reason.

---

# 3. Draft PRs were never gated or approved

Review finding on §1, fixed in the same branch.

Both jobs in the shared `pr-quality.yml` are gated on
`github.event.pull_request.draft == false`. The caller subscribed only to
`[opened, synchronize, reopened]`, so a PR opened as a draft was skipped —
and marking it ready for review emitted `ready_for_review`, which the caller
did not listen for. The PR then stayed unchecked and unapproved until an
unrelated push happened to produce a `synchronize` event.

Fixed caller-side by adding the `ready_for_review` activity type. The
reusable's draft gate is correct as written and is left alone.

## Not changed: the `actions/checkout` flag

A review comment asked whether `pr-quality.yml` is the wrong reusable for a
`pull_request_target` caller because it performs `actions/checkout`. It is
not a defect and nothing was changed for it:

- the checkout has no `ref:`, and under `pull_request_target` `github.ref` /
  `github.sha` resolve to the **base** branch — PR head code is never fetched;
- it sets `persist-credentials: false`;
- no repository code is executed anywhere in the reusable — every step is
  `actions/github-script` operating against the API.

---

## Verification

Run on this branch after all three changes:

- `actionlint .github/workflows/auto-merge-deps.yml .github/workflows/pr-quality.yml` → exit 0
- `actionlint` rejects an invalid activity-type name for `pull_request_target`
  (confirmed by deliberately mis-spelling it → exit 1), so `ready_for_review`
  is a checked spelling, not an assumption
- `gh api repos/netresearch/node-red-contrib-magento-eqp` for the merge-method
  facts behind the `merge-strategy: rebase` pin
- both reusables read in full from `netresearch/.github@main` to derive the
  job-level `permissions:` unions
- live API probes for the permission-lookup and secret-availability claims in §1

Scope: `.github/workflows/pr-quality.yml` and
`.github/workflows/auto-merge-deps.yml`. `release.when-tagged.yml` and
`release-please.yml` are untouched.
