### PR TITLE
ci: publish via the shared node-release reusable

### DIFF
--- a/.github/workflows/release.when-tagged.yml
+++ b/.github/workflows/release.when-tagged.yml
@@ -1,10 +1,22 @@
 # Publish and create GitHub Release when a signed tag is pushed.
 # Triggered by: git tag -s vX.Y.Z -m "vX.Y.Z" && git push origin vX.Y.Z
-# Also available via workflow_dispatch for manual reruns.
+# Also available via workflow_dispatch for manual reruns — select the vX.Y.Z
+# TAG as the run ref, not a branch: version-source manifest-verified needs a
+# tag ref and fails with a clear message otherwise.
 #
-# npm authentication uses OIDC trusted publishing (no NPM_TOKEN needed).
-# Setup: https://www.npmjs.com/package/@netresearch/node-red-contrib-magento-eqp/access
-# -> Trusted Publisher -> GitHub Actions -> workflow: release.when-tagged.yml
+# Thin caller of the shared node-release reusable: build, npm publish (OIDC
+# Trusted Publishing, no token), the GitHub Packages pass, and the GitHub
+# Release all live in netresearch/.github. Zero step-level `uses:`.
+#
+# THE FILENAME MUST STAY release.when-tagged.yml. npm Trusted Publishing
+# validates the CALLER workflow's filename, not the reusable that runs
+# `npm publish`, so the Trusted Publisher on npmjs.com
+# (@netresearch/node-red-contrib-magento-eqp -> Trusted Publisher -> Workflow:
+# release.when-tagged.yml) keeps matching only while this filename is unchanged.
+#
+# HUSKY=0 is replaced by `--ignore-scripts` on install, which skips the
+# package.json `prepare: husky` hook the same way. `prepack` still runs at
+# publish time (it is a pack-time hook, unaffected by install --ignore-scripts).
 
 name: 📦☁️ Release
 
@@ -14,53 +26,26 @@ on:
     tags:
       - 'v*'
 
-permissions:
-  contents: write
-  packages: write
-  id-token: write # OIDC trusted publishing to npm
-
-env:
-  HUSKY: '0'
+permissions: {}
 
 jobs:
   release:
-    name: 📦☁️ Publish and release
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-        with:
-          bun-version: 1.3.14
-
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: 24
-          registry-url: 'https://registry.npmjs.org'
-          scope: '@netresearch'
-
-      - name: ⚡ Install dependencies
-        run: bun install --frozen-lockfile
-
-      - name: 🔨 Build
-        run: bun run build:lib
-
-      - name: ☁️ Publish to NPM (OIDC + provenance)
-        run: npm publish --access=public --provenance
-
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: 24
-          registry-url: 'https://npm.pkg.github.com'
-          scope: '@netresearch'
-
-      - name: ☁️ Publish to GitHub Package Registry
-        run: npm publish --access=public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: 📋 Create GitHub Release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ github.ref_name }}
-        run: gh release create "$TAG" --generate-notes
+    uses: netresearch/.github/.github/workflows/node-release.yml@main
+    permissions:
+      contents: write
+      id-token: write
+      packages: write
+    with:
+      runs-on: ubuntu-24.04
+      package-manager: bun
+      node-version: '24'
+      bun-version: 1.3.14
+      install-cmd: bun install --frozen-lockfile --ignore-scripts
+      build-cmd: bun run build:lib
+      version-source: manifest-verified
+      publish-npm: true
+      npm-access: public
+      provenance: true
+      publish-github-packages: true
+      skip-if-published: true
+      create-github-release: true


### PR DESCRIPTION
Turns `release.when-tagged.yml` into a thin caller of the shared [`node-release.yml`](https://github.com/netresearch/.github/blob/main/.github/workflows/node-release.yml) reusable ([netresearch/.github#301](https://github.com/netresearch/.github/pull/301)), removing every step-level third-party action from this release workflow.

### Behaviour preserved

| | before | after |
|---|---|---|
| npm publish | OIDC + provenance | `publish-npm` + `provenance: true` |
| GitHub Packages | second `npm publish` | `publish-github-packages: true` |
| GitHub Release | `gh release create --generate-notes` | `create-github-release: true` |
| tag vs manifest | (varies) | `version-source: manifest-verified` — hard-fails a mis-tag |
| husky suppression | `HUSKY=0` | `install --ignore-scripts` |

### The filename is deliberately unchanged

npm Trusted Publishing validates the **calling** workflow's filename, not the reusable that runs `npm publish` ([npm docs](https://docs.npmjs.com/trusted-publishers)). The Trusted Publisher for `@netresearch/node-red-contrib-magento-eqp` is bound to `release.when-tagged.yml`, so this PR edits the file **in place** and keeps its name — Trusted Publishing keeps matching.

### One thing to know before the first release after merge

- **This PR publishes nothing** — publishing only fires on the next real version tag.
- Confirm on npmjs.com that the Trusted Publisher for `@netresearch/node-red-contrib-magento-eqp` still lists workflow `release.when-tagged.yml` (it should — the filename is unchanged). This is the one thing that can't be checked from the repo.
- A `workflow_dispatch` rerun must select the **tag** as the ref (not a branch): `manifest-verified` needs a tag ref and fails with a clear message otherwise.

The release-time `test` + `lint` gate is not reproduced here — `main` requires CI green (a required status check) and tags are cut from `main`.