### PR TITLE
ci: route Release Please through central reusable

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,16 +7,13 @@ on:
   push:
     branches: [main]
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   release-please:
     name: 📋 Release Please
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
-        with:
-          release-type: node
-          skip-github-release: true
+    uses: netresearch/.github/.github/workflows/release-please.yml@main
+    permissions:
+      contents: write
+      pull-requests: write
+    with:
+      release-type: node
+      skip-github-release: true


### PR DESCRIPTION
Replaces the inline `googleapis/release-please-action` job with a call to the shared `netresearch/.github` `release-please.yml` reusable, so the external action is no longer pinned in this repo (managed centrally). Behavior unchanged: `release-type: node`, `skip-github-release: true`.